### PR TITLE
Fix full match regex matching

### DIFF
--- a/src/regex_based_matcher.rs
+++ b/src/regex_based_matcher.rs
@@ -13,25 +13,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::regex_util::{RegexConsume, RegexFullMatch};
+use log::error;
 
-use log::{error};
-use super::regex_util::{RegexFullMatch, RegexConsume};
-
-use crate::{interfaces, generated::proto::phonemetadata::PhoneNumberDesc, regexp_cache::{InvalidRegexError, RegexCache}};
+use crate::{
+    generated::proto::phonemetadata::PhoneNumberDesc,
+    interfaces,
+    regexp_cache::{InvalidRegexError, RegexCache},
+};
 
 pub struct RegexBasedMatcher {
-    cache: RegexCache,   
+    cache: RegexCache,
 }
 
 impl RegexBasedMatcher {
     pub fn new() -> Self {
-        Self { cache: RegexCache::with_capacity(128) }
+        Self {
+            cache: RegexCache::with_capacity(128),
+        }
     }
 
     fn match_number(
-        &self, phone_number: &str, 
+        &self,
+        phone_number: &str,
         number_pattern: &str,
-        allow_prefix_match: bool
+        allow_prefix_match: bool,
     ) -> Result<bool, InvalidRegexError> {
         let regexp = self.cache.get_regex(number_pattern)?;
 
@@ -46,9 +52,10 @@ impl RegexBasedMatcher {
 
 impl interfaces::MatcherApi for RegexBasedMatcher {
     fn match_national_number(
-        &self, number: &str, 
-        number_desc: &PhoneNumberDesc, 
-        allow_prefix_match: bool
+        &self,
+        number: &str,
+        number_desc: &PhoneNumberDesc,
+        allow_prefix_match: bool,
     ) -> bool {
         let national_number_pattern = number_desc.national_number_pattern();
         // We don't want to consider it a prefix match when matching non-empty input
@@ -62,5 +69,109 @@ impl interfaces::MatcherApi for RegexBasedMatcher {
             error!("Invalid regex! {}", national_number_pattern);
             false
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::generated::proto::phonemetadata::PhoneNumberDesc;
+    use crate::interfaces::MatcherApi;
+    use crate::regex_based_matcher::RegexBasedMatcher;
+
+    fn to_string(desc: &PhoneNumberDesc) -> String {
+        let pattern = if !desc.national_number_pattern().is_empty() {
+            desc.national_number_pattern()
+        } else {
+            "none"
+        };
+        format!("pattern: {}", pattern)
+    }
+
+    fn expect_matched(matcher: &impl MatcherApi, number: &str, desc: &PhoneNumberDesc) {
+        assert!(
+            matcher.match_national_number(number, desc, false),
+            "{} should have matched {}",
+            number,
+            to_string(desc)
+        );
+        assert!(
+            matcher.match_national_number(number, desc, true),
+            "{} should have matched {}",
+            number,
+            to_string(desc)
+        );
+    }
+
+    fn expect_invalid(matcher: &impl MatcherApi, number: &str, desc: &PhoneNumberDesc) {
+        assert!(
+            !matcher.match_national_number(number, desc, false),
+            "{} should not have matched {}",
+            number,
+            to_string(desc)
+        );
+        assert!(
+            !matcher.match_national_number(number, desc, true),
+            "{} should not have matched {}",
+            number,
+            to_string(desc)
+        );
+    }
+
+    fn expect_too_long(matcher: &impl MatcherApi, number: &str, desc: &PhoneNumberDesc) {
+        assert!(
+            !matcher.match_national_number(number, desc, false),
+            "{} should have been too long for {}",
+            number,
+            to_string(desc)
+        );
+        assert!(
+            matcher.match_national_number(number, desc, true),
+            "{} should have been too long for {}",
+            number,
+            to_string(desc)
+        );
+    }
+
+    fn create_desc(national_number_pattern: &str) -> PhoneNumberDesc {
+        let mut desc = PhoneNumberDesc::default();
+        if !national_number_pattern.is_empty() {
+            desc.set_national_number_pattern(national_number_pattern.to_string());
+        }
+        desc
+    }
+
+    fn check_matcher_behaves_as_expected(matcher: &impl MatcherApi) {
+        let mut desc;
+
+        desc = create_desc("");
+        // Test if there is no matcher data.
+        expect_invalid(matcher, "1", &desc);
+
+        desc = create_desc(r"9\d{2}");
+        expect_invalid(matcher, "91", &desc);
+        expect_invalid(matcher, "81", &desc);
+        expect_matched(matcher, "911", &desc);
+        expect_invalid(matcher, "811", &desc);
+        expect_too_long(matcher, "9111", &desc);
+        expect_invalid(matcher, "8111", &desc);
+
+        desc = create_desc(r"\d{1,2}");
+        expect_matched(matcher, "2", &desc);
+        expect_matched(matcher, "20", &desc);
+
+        desc = create_desc("20?");
+        expect_matched(matcher, "2", &desc);
+        expect_matched(matcher, "20", &desc);
+
+        desc = create_desc("2|20");
+        expect_matched(matcher, "2", &desc);
+        // Subtle case where lookingAt() and matches() result in different end()s.
+        expect_matched(matcher, "20", &desc);
+    }
+
+    #[test]
+    fn test_regex_based_matcher() {
+        let matcher = RegexBasedMatcher::new();
+        check_matcher_behaves_as_expected(&matcher);
     }
 }

--- a/src/regex_util.rs
+++ b/src/regex_util.rs
@@ -31,11 +31,12 @@ pub trait RegexConsume {
 
 impl RegexFullMatch for Regex {
     fn full_match(&self, s: &str) -> bool {
-        let found = self.find(s);
-        if let Some(matched) = found {
-            return matched.start() == 0 && matched.end() == s.len();
+        let pattern = format!("^(?:{})$", self.as_str());
+        if let Ok(anchored_re) = Regex::new(&pattern) {
+            anchored_re.is_match(s)
+        } else {
+            false
         }
-        false
     }
 }
 
@@ -44,7 +45,7 @@ impl RegexConsume for Regex {
         let captures = self.captures(s)?;
         let full_capture = captures.get(0)?;
         if full_capture.start() != 0 {
-            return None
+            return None;
         }
 
         Some(captures)
@@ -53,7 +54,7 @@ impl RegexConsume for Regex {
     fn find_start<'a>(&self, s: &'a str) -> Option<Match<'a>> {
         let found = self.find(s)?;
         if found.start() != 0 {
-            return None
+            return None;
         }
         Some(found)
     }


### PR DESCRIPTION
The full_match regex matching was not working for edge case like `regex=2|20` and `haystack=20` because rust only gives the leftmost match when using `find`. Wrapping the regex string with the `^..$` anchors replicates the C/Java behaviors of `matches`